### PR TITLE
Local externals with new OTB defaults, minor bug fixes, remove unused code

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,9 +9,9 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.8.42
+branch = mpas_dev/cime5.8.42
 protocol = git
-repo_url = https://github.com/ESMCI/cime.git
+repo_url = https://github.com/jtruesdal/cime.git
 local_path = cime
 required = True
 
@@ -24,9 +24,9 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = ctsm5.1.dev019
+tag = ctsm5.1.dev019_mpas_fixes
 protocol = git
-repo_url = https://github.com/ESCOMP/ctsm
+repo_url = https://github.com/jtruesdal/ctsm
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -244,7 +244,7 @@
 
 <ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8"       nlev="70" ic_ymd="101">atm/waccm/ic/FW2000_CONUS_30x8_L70_01-01-0001_c200602.nc</ncdata>
 
-<ncdata hgrid="mpasa120" nlev="32" >atm/cam/inic/mpas/mpasa120_L32_init.umjs.dry_c201021.nc</ncdata>
+<ncdata hgrid="mpasa120" nlev="32" >atm/cam/inic/mpas/mpasa120.CFSR.L32.nc'</ncdata>
 
 <!-- Topography -->
 <bnd_topo hgrid="256x512" >atm/cam/topo/topo-from-cami_0000-01-01_256x512_L26_c030918.nc</bnd_topo>

--- a/src/dynamics/mpas/dp_coupling.F90
+++ b/src/dynamics/mpas/dp_coupling.F90
@@ -13,7 +13,6 @@ use physconst,      only: gravit, cpairv, cappa, rairv, rh2o, zvir
 use spmd_dyn,       only: local_dp_map, block_buf_nrecs, chunk_buf_nrecs
 use spmd_utils,     only: mpicom, iam, masterproc
 
-use dyn_grid,       only: get_gcol_block_d
 use dyn_comp,       only: dyn_export_t, dyn_import_t
 
 use physics_types,  only: physics_state, physics_tend

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -1044,7 +1044,7 @@ subroutine read_inidat(dyn_in)
    ! If scale_dry_air_mass < 0.0, then use the reference pressures defined in physconst.F90 as the
    ! target global average dry pressure to scale to. If scale_dry_air_mass is not zero, then use it
    ! as the target.
-   if (simple_phys /= .true. .and. scale_dry_air_mass /= 0.0) then  ! Don't scale air mass if < 0. or simple_phys is on
+   if (.not. simple_phys .and. scale_dry_air_mass /= 0.0) then  ! Don't scale air mass if < 0. or simple_phys is on
        if (scale_dry_air_mass < 0.0) then
            target_global_avg_dry_ps = ps_dry_topo
            if (.not. associated(fh_topo)) then


### PR DESCRIPTION
Update for cam_mpas_dev to allow more compsets to work out of the box. F2000climo mpasa120 should work now.  Removed unused code due to weak scaling updates and fixed a minor syntax error caught by NAG.  @MiCurry could you run a minimal test that verifies that the runs you advertised to the MPAS development community still work.  I'd like to put in some regression tests for those (maybe with a category of aux_cam_mpas for Cheyenne and Izumi) that we can run for each of our PR's. For now, I ran 2 tests out of cime/scripts on Cheyenne and Izumi:

1. ./create_test ERC_D_Ln9.mpasa120_mpasa120.F2000climo.cheyenne_intel.cam-outfrq3s
2. ./create_test ERC_D_Ln9.mpasa120_mpasa120.F2000climo.izumi_nag.cam-outfrq3s (still running!!!)
