### PR TITLE
Fix bug which computed dry surface pressure incorrectly for log output

### DIFF
--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -1637,7 +1637,7 @@ subroutine set_dry_mass(dyn_in, target_avg_dry_surface_pressure)
    do i = 1, nCellsSolve
        preliminary_dry_surface_pressure(i) = 0.0_r8
        do k = 1, plev
-           preliminary_dry_surface_pressure(i) = preliminary_dry_surface_pressure(i) + gravity*(zint(k+1,i)-zint(k,1))*rho(k,i)
+           preliminary_dry_surface_pressure(i) = preliminary_dry_surface_pressure(i) + gravity*(zint(k+1,i)-zint(k,i))*rho(k,i)
        end do
    end do
    preliminary_dry_surface_pressure(1:nCellsSolve) = preliminary_dry_surface_pressure(1:nCellsSolve)*areaCell(1:nCellsSolve)


### PR DESCRIPTION
This commit fixes a bug which incorrectly computed the dry surface pressure
after it had been scaled. This dry surface pressure computation is only being
written out to the log and is not used elsewhere by the model, thus this bug
caused no issues other then incorrect log reports.